### PR TITLE
Adding a way to filter the plugin url, reason being if the plugin lives ...

### DIFF
--- a/voce-post-meta-date.php
+++ b/voce-post-meta-date.php
@@ -77,10 +77,11 @@ class Voce_Post_Meta_Date {
 			if( !empty( $relative_path ) && is_string( $relative_path ) && strpos( $relative_path, '..' ) === false ) {
 				$url .= '/' . ltrim( $relative_path, '/' );
 			}
-			return $url;
 		} else {
-			return plugins_url( $relative_path, $plugin_path );
+			$url = plugins_url( $relative_path, $plugin_path );
 		}
+
+		$url = apply_filters( 'voce-post-meta-date_plugins_url', $url, $relative_path, $plugin_path );
 	}
 
 	/**

--- a/voce-post-meta-date.php
+++ b/voce-post-meta-date.php
@@ -81,7 +81,7 @@ class Voce_Post_Meta_Date {
 			$url = plugins_url( $relative_path, $plugin_path );
 		}
 
-		$url = apply_filters( 'voce-post-meta-date_plugins_url', $url, $relative_path, $plugin_path );
+		return apply_filters( 'voce-post-meta-date_plugins_url', $url, $relative_path, $plugin_path );
 	}
 
 	/**


### PR DESCRIPTION
...within a child theme, template directory will not work.  Having the ability to filter this url will allow the usage of the stylesheet directory.
